### PR TITLE
add api service wrapper and implement start and end

### DIFF
--- a/app/api.service/api.service.ts
+++ b/app/api.service/api.service.ts
@@ -8,7 +8,7 @@ import * as socketio from 'socket.io-client';
 export class ApiService {
     private socket: SocketIOClient.Socket;
     session: Session = new Session();
-    apiUrl:string = config.serviceUrl + '/api';
+    apiUrl: string = config.serviceUrl + '/api';
 
     constructor(private http: Http) {
         //connect to the socket server
@@ -17,14 +17,22 @@ export class ApiService {
         //stream all messages into our Rx Subject
         this.socket.on("message", d => {
             //handle socket messages
+
         });
     }
 
+    fetch() {
+        this.http.get(this.apiUrl + '/session')
+            .subscribe(response => this.session = response.json());
+    }
+
     start() {
-        this.http.post(this.apiUrl + '/session/start', null);
+        this.http.post(this.apiUrl + '/session/start', null)
+            .subscribe(() => this.fetch(), err => console.error(`Error starting session. ${err}`));
     }
 
     end() {
-        this.http.post(this.apiUrl + '/session/end', null);
+        this.http.post(this.apiUrl + '/session/end', null)
+            .subscribe(() => this.fetch(), err => console.error(`Error ending session. ${err}`));
     }
 }

--- a/app/session.component/session.component.html
+++ b/app/session.component/session.component.html
@@ -12,3 +12,12 @@
     </template>
   </md-tab>
 </md-tab-group>
+
+Session status: {{ api.session.status }}<br/>
+
+<button md-raised-button (click)="api.start()" [color]="'primary'" >
+    START
+</button>
+<button md-raised-button (click)="api.end()" [color]="'warn'" >
+    END
+</button>

--- a/app/session.component/session.component.ts
+++ b/app/session.component/session.component.ts
@@ -1,5 +1,6 @@
 import { Component, provide, OnInit } from "@angular/core";
 import { MD_TABS_DIRECTIVES } from "@angular2-material/tabs";
+import { MD_BUTTON_DIRECTIVES } from "@angular2-material/button";
 import { SessionTableComponent } from '../session-table.component/session-table.component';
 import { VisualComponent } from '../visual.component/visual.component';
 import { ApiService } from '../api.service/api.service';
@@ -9,7 +10,7 @@ import { ApiService } from '../api.service/api.service';
     templateUrl: "app/session.component/session.component.html",
     styleUrls:["app/session.component/session.component.css"],
     providers:[ApiService],
-    directives: [MD_TABS_DIRECTIVES, SessionTableComponent, VisualComponent]
+    directives: [MD_BUTTON_DIRECTIVES, MD_TABS_DIRECTIVES, SessionTableComponent, VisualComponent]
 })
 export class SessionComponent implements OnInit{
     rowers = [


### PR DESCRIPTION
This is working including updating the UI on status change. Currently the update is triggered by a call to the start and end methods. Eventually, that should be triggered by a web socket. This is a good start on a service wrapper though.
Someone give me a 👍  and I'll merge this into master.