### PR TITLE
Send session-start and session-end messages (for Issue32)

### DIFF
--- a/app/api.service/api.service.ts
+++ b/app/api.service/api.service.ts
@@ -37,11 +37,17 @@ export class ApiService {
     start() {
         // we can fire and forget this because it will trigger a session-change socket message and we (the UI) will be updated accordingly
         this.http.post(this.apiUrl + '/session/start', null)
-            .subscribe({ error: err => console.error(`Error starting session. ${err}`) });
+            .subscribe({
+                next: () => this.socket.send({ message: 'session-start', distance: 150 }),
+                error: err => console.error(`Error starting session. ${err}`)
+            });
     }
 
     end() {
         this.http.post(this.apiUrl + '/session/end', null)
-            .subscribe({ error: err => console.error(`Error ending session. ${err}`) });
+            .subscribe({
+                next: () => this.socket.send({ message: 'session-end', distance: 150 }),
+                error: err => console.error(`Error ending session. ${err}`)
+            });
     }
 }

--- a/app/session.component/session.component.html
+++ b/app/session.component/session.component.html
@@ -15,8 +15,6 @@
 
 <div (window:keydown)="handleKeypress($event)"></div>
 
-Session status: {{ api.session.status }}<br/>
-
 <button md-raised-button
   (click)="(api.session.status == 'active' ? api.end() : api.start())"
   [color]="(api.session.status == 'active' ? 'warn' : 'primary')"


### PR DESCRIPTION
this is so the device can respond by doing a rower reset and starting a new workout with the desired distance