### PR TITLE
Status toolbar + countdown

### DIFF
--- a/app/session.component/session.component.css
+++ b/app/session.component/session.component.css
@@ -1,3 +1,16 @@
 :host {
 
 }
+
+.fill-remaining-space {
+  flex: 1 1 auto;
+}
+
+#countdown{
+  width:90vw;
+  position: fixed;
+  z-index: 100;
+  text-align: center;
+  font-size: 50vw;  
+  font-family: sans-serif;
+}

--- a/app/session.component/session.component.html
+++ b/app/session.component/session.component.html
@@ -1,8 +1,15 @@
 <md-toolbar 
 [color]="(api.session.status == 'active' ? 'primary' : 'accent')">
-  <span>
-    {{ (api.session.status == 'active' ? 'Session began' : 'Click start to begin a session.') }}
+  <span id="toolbar">
+    {{ (api.session.status == 'active' ? 'Session began ' + date : 'Click start to begin a new session.') }}
   </span>
+  <span class="fill-remaining-space"></span>
+  <button md-raised-button
+  (click)="(api.session.status == 'active' ? api.end() : countdownStart())"
+  [color]="(api.session.status == 'active' ? 'warn' : 'primary')" >
+  <!--[disabled]="(api.session.rowers.length == 0)" >-->
+    {{ (api.session.status == 'active' ? 'END' : 'START') }}
+</button>
 </md-toolbar>
 <md-tab-group [selectedIndex]="index">
   <md-tab>
@@ -20,13 +27,7 @@
 </md-tab-group>
 
 <div (window:keydown)="handleKeypress($event)"></div>
-
-<button md-raised-button
-  (click)="(api.session.status == 'active' ? api.end() : api.start())"
-  [color]="(api.session.status == 'active' ? 'warn' : 'primary')"
-  [disabled]="(api.session.rowers.length == 0)" >
-    {{ (api.session.status == 'active' ? 'END' : 'START') }}
-</button>
+<div id="countdown"></div>
 
 <!--Commented out progress bar temporarily-->
 <!--<md-card>

--- a/app/session.component/session.component.html
+++ b/app/session.component/session.component.html
@@ -1,3 +1,9 @@
+<md-toolbar 
+[color]="(api.session.status == 'active' ? 'primary' : 'accent')">
+  <span>
+    {{ (api.session.status == 'active' ? 'Session began' : 'Click start to begin a session.') }}
+  </span>
+</md-toolbar>
 <md-tab-group [selectedIndex]="index">
   <md-tab>
     <template md-tab-label>Data</template>
@@ -22,8 +28,8 @@
     {{ (api.session.status == 'active' ? 'END' : 'START') }}
 </button>
 
-
-<md-card>
+<!--Commented out progress bar temporarily-->
+<!--<md-card>
   <label>
     Determinate Progress bar - {{progress}}%
     <md-progress-bar
@@ -33,4 +39,4 @@
       [value]="progress"
       aria-label="Determinate progress-bar example"></md-progress-bar>
   </label>
-</md-card>
+</md-card>-->

--- a/app/session.component/session.component.ts
+++ b/app/session.component/session.component.ts
@@ -1,7 +1,8 @@
 import { Component, provide, OnInit } from "@angular/core";
 import { MD_TABS_DIRECTIVES } from "@angular2-material/tabs";
 import { MD_BUTTON_DIRECTIVES } from "@angular2-material/button";
-import {MD_PROGRESS_BAR_DIRECTIVES} from '@angular2-material/progress-bar';
+//import {MD_PROGRESS_BAR_DIRECTIVES} from '@angular2-material/progress-bar';
+import {MD_TOOLBAR_DIRECTIVES} from '@angular2-material/toolbar';
 import { SessionTableComponent } from '../session-table.component/session-table.component';
 import { VisualComponent } from '../visual.component/visual.component';
 import { ApiService } from '../api.service/api.service';
@@ -11,24 +12,47 @@ import { ApiService } from '../api.service/api.service';
     templateUrl: "app/session.component/session.component.html",
     styleUrls:["app/session.component/session.component.css"],
     providers:[ApiService],
-    directives: [MD_BUTTON_DIRECTIVES, MD_TABS_DIRECTIVES, MD_PROGRESS_BAR_DIRECTIVES, SessionTableComponent, VisualComponent]
+    directives: [MD_BUTTON_DIRECTIVES, MD_TABS_DIRECTIVES, MD_TOOLBAR_DIRECTIVES, SessionTableComponent, VisualComponent]
 })
 export class SessionComponent implements OnInit{
     index: number = 0; 
     TAB_COUNT: number = 2;
+    //progress: number = 0; 
+    timer;
+    date;
+    countdownindex: number = 3;
 
-    progress: number = 0; 
-
+    
     constructor(private api:ApiService) {
-
+        // Commented out progress bar temporarily.
         // UPdate the value for the progress-bar on an interval. 
-        setInterval(() => {
-            this.progress = (this.progress + Math.floor(Math.random() * 4) + 1) % 100; 
-        }, 200);
+        // setInterval(() => {
+        //     this.progress = (this.progress + Math.floor(Math.random() * 4) + 1) % 100; 
+        // }, 200);
     }
-
+    
     ngOnInit() {
         this.api.fetch();
+    }
+
+    countdownStart(){
+        this.timer = setInterval(() => this.countdown(), 1000);
+    }
+
+    countdown() {
+        if (this.countdownindex === 0) { this.countdownEnd(); }
+        else { 
+            document.getElementById('countdown').innerText = ""+this.countdownindex; 
+            this.countdownindex--;
+        }
+    }
+
+    countdownEnd(){
+        clearTimeout(this.timer);
+        document.getElementById('countdown').innerText = "";
+        this.countdownindex = 3;
+        this.date = new Date();
+        this.api.start();
     }
 
     handleKeypress(event) { 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular2-material/card": "2.0.0-alpha.6-2",
     "@angular2-material/core": "2.0.0-alpha.6-2",
     "@angular2-material/tabs": "2.0.0-alpha.6-2",
+    "@angular2-material/toolbar": "^2.0.0-alpha.6-2",
     "@angular2-material/progress-bar": "2.0.0-alpha.6-2",
     "es6-shim": "0.35.1",
     "reflect-metadata": "0.1.3",

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -39,6 +39,11 @@
             format: 'cjs',
             defaultExtension: 'js',
             main: 'progress-bar.js'
+        },
+        '@angular2-material/toolbar': {
+            format: 'cjs',
+            defaultExtension: 'js',
+            main: 'toolbar.js'
         }
     };
 


### PR DESCRIPTION
First draft of dynamic status bar, start/end buttons, and countdown timer. 

Things to be addressed:

- Replace timestamp with something more human-readable (i.e., "Session began X seconds ago.") via momentjs.

- Countdown should be housed in a different Material component, but many of the ideal components are still being finalized and aren't yet available for use.
